### PR TITLE
Mark CSS files as not sideeffect-free

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dist"
   ],
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": ["**/*.css"],
   "scripts": {
     "build": "npm run build:clean && npm run build:browser-dev && npm run build:browser-prod && npm run build:lib",
     "build:browser-dev": "vite build --mode browser",


### PR DESCRIPTION
With `sideEffects: false`, webpack's production tree-shaker considers every module in the package — including CSS — as pure, so the CSS import generated by Nuxt's `css: []` entry gets dropped from the production bundle.